### PR TITLE
Support interrupting long running Earley parses.

### DIFF
--- a/edu/isi/tiburon/Debug.java
+++ b/edu/isi/tiburon/Debug.java
@@ -22,6 +22,12 @@ public class Debug {
 	    w = new OutputStreamWriter(System.err);
 	}
     }
+
+	public static void checkInterrupted() {
+		if (Thread.currentThread().isInterrupted()) {
+			throw new RuntimeException("interrupted");
+		}
+	}
     
     // for debugging
 

--- a/edu/isi/tiburon/EarleyState.java
+++ b/edu/isi/tiburon/EarleyState.java
@@ -1072,6 +1072,10 @@ public class EarleyState implements Serializable {
 			Symbol[][][] newSyms, 
 			ArrayList<EarleyState> todoList,
 			RTGRuleSet parent, StringTransducerRule[] ruleset) throws ImproperConversionException {
+		if (Thread.interrupted()) {
+			throw new RuntimeException("interrupted");
+		}
+
 		boolean debug = false;
 		// there used to be a done list, but this flag is good enough
 		this.isDone = true;

--- a/edu/isi/tiburon/EarleyState.java
+++ b/edu/isi/tiburon/EarleyState.java
@@ -1072,7 +1072,7 @@ public class EarleyState implements Serializable {
 			Symbol[][][] newSyms, 
 			ArrayList<EarleyState> todoList,
 			RTGRuleSet parent, StringTransducerRule[] ruleset) throws ImproperConversionException {
-		if (Thread.interrupted()) {
+		if (Thread.currentThread().isInterrupted()) {
 			throw new RuntimeException("interrupted");
 		}
 

--- a/edu/isi/tiburon/EarleyState.java
+++ b/edu/isi/tiburon/EarleyState.java
@@ -1072,9 +1072,7 @@ public class EarleyState implements Serializable {
 			Symbol[][][] newSyms, 
 			ArrayList<EarleyState> todoList,
 			RTGRuleSet parent, StringTransducerRule[] ruleset) throws ImproperConversionException {
-		if (Thread.currentThread().isInterrupted()) {
-			throw new RuntimeException("interrupted");
-		}
+		Debug.checkInterrupted();
 
 		boolean debug = false;
 		// there used to be a done list, but this flag is good enough

--- a/edu/isi/tiburon/RTGRuleSet.java
+++ b/edu/isi/tiburon/RTGRuleSet.java
@@ -104,6 +104,8 @@ public class RTGRuleSet extends RuleSet {
 
 	// recursively search for terminal symbols
 	public HashSet findTerminals(Item i) {
+		Debug.checkInterrupted();
+
 		TreeItem t = (TreeItem) i;
 		HashSet s = new HashSet();
 		// transducer state terminals don't count as real terminals
@@ -3161,7 +3163,8 @@ public class RTGRuleSet extends RuleSet {
 	// returns and memoizes the leaves of a rule that are states
 	// in general some bad coding...
 	public Vector<Symbol> getLeafChildren(Rule r) {
-		if (Thread.currentThread().isInterrupted()) { throw new RuntimeException("interrupted"); }
+		Debug.checkInterrupted();
+
 		if (!leafChildren.containsKey(r)) {
 			Vector<Symbol> v = new Vector<Symbol>();
 			Symbol [] syms = ((RTGRule)r).getRHSLeaves();
@@ -3745,6 +3748,8 @@ public class RTGRuleSet extends RuleSet {
 		boolean printChart = false;
 		semiring = trs.semiring;
 		nextRuleIndex = 0;
+
+		Debug.checkInterrupted();
 
 		EarleyState.resetParseMemo();
 		HashSet<EarleyState>[][] finishedChart = trs.parse(string, beam, timeLevel);

--- a/edu/isi/tiburon/RTGRuleSet.java
+++ b/edu/isi/tiburon/RTGRuleSet.java
@@ -3161,6 +3161,7 @@ public class RTGRuleSet extends RuleSet {
 	// returns and memoizes the leaves of a rule that are states
 	// in general some bad coding...
 	public Vector<Symbol> getLeafChildren(Rule r) {
+		if (Thread.currentThread().isInterrupted()) { throw new RuntimeException("interrupted"); }
 		if (!leafChildren.containsKey(r)) {
 			Vector<Symbol> v = new Vector<Symbol>();
 			Symbol [] syms = ((RTGRule)r).getRHSLeaves();

--- a/edu/isi/tiburon/StringTransducerRuleSet.java
+++ b/edu/isi/tiburon/StringTransducerRuleSet.java
@@ -2083,7 +2083,8 @@ public class StringTransducerRuleSet extends TransducerRuleSet {
 		preds[s2i.get(getStartState())][0] = true;
 	//	preds.put(s2i.get(getStartState()), startint);
 		while (!agenda.isEmpty()) {
-			
+			Debug.checkInterrupted();
+
 //			if (agenda.size() % 1000 == 0) {
 //				Debug.prettyDebug(agenda.size()+" in agenda");
 //			}

--- a/edu/isi/tiburon/Tiburon.java
+++ b/edu/isi/tiburon/Tiburon.java
@@ -3143,14 +3143,14 @@ public class Tiburon {
 		}
 		catch (Exception e) {
 			System.err.println("Throwing generic exception of type "+e.getClass().toString());
-			StackTraceElement elements[] = e.getStackTrace();
-			int n = elements.length;
-			for (int i = 0; i < n; i++) {       
-				System.err.println(e.toString()+": "+elements[i].getFileName() + ":" 
-						+ elements[i].getLineNumber() 
-						+ ">> " 
-						+ elements[i].getMethodName() + "()");
-			}
+//			StackTraceElement elements[] = e.getStackTrace();
+//			int n = elements.length;
+//			for (int i = 0; i < n; i++) {
+//				System.err.println(e.toString()+": "+elements[i].getFileName() + ":"
+//						+ elements[i].getLineNumber()
+//						+ ">> "
+//						+ elements[i].getMethodName() + "()");
+//			}
 			throw e;
 		}
 	}


### PR DESCRIPTION
The tree to string transducer, using Earley behind the scenes, insists of constructing the full RTG even when using bestk parsing. This is expensive for very ambiguous grammars. Adding a mechanism to forcefully interrupt the transduction after a while.
